### PR TITLE
Add check_note command

### DIFF
--- a/Batteries/Util/LibraryNote.lean
+++ b/Batteries/Util/LibraryNote.lean
@@ -35,6 +35,34 @@ creates a new "library note", which can then be cross-referenced using
 -- See note [some tag]
 ```
 in doc-comments.
+Use `#check_note "some tag"` to display all notes with the tag 
+`"some tag"` in the infoview.
 -/
 elab "library_note " title:strLit ppSpace text:docComment : command => do
   modifyEnv (libraryNoteExt.addEntry · (title.getString, text.getDocString))
+
+/--
+`#check_note "some tag"` displays all library notes with tag 
+`"some tag"` in the infoview.
+The command only displays the library notes that are declared in 
+imported files or in the same file above the line containing the command.
+-/
+elab "#check_note" name:strLit : command => do
+  let env ← getEnv
+  
+  -- get the library notes from both this and imported files
+  let local_entries := libraryNoteExt.getEntries env
+  let imported_entries := (libraryNoteExt.toEnvExtension.getState env).importedEntries
+
+  -- filter for the appropriate notes while casting to list
+  let entry_name := name.getString
+  let imported_entries_filtered := imported_entries.flatten.toList.filterMap
+    (fun x => if x.fst == entry_name then Option.some x.snd else Option.none)
+  let valid_entries := imported_entries_filtered ++ local_entries.filterMap 
+    (fun x => if x.fst == entry_name then some x.snd else none)
+
+  -- display results in a readable style
+  if valid_entries.isEmpty then
+    logInfo "Note not found"
+  else
+    logInfo <| "\n\n".intercalate <| valid_entries.reverse.map ("/--" ++ · ++ "-/") 


### PR DESCRIPTION
on [zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Where.20to.20find.20.22notes.22) it was mentioned that there used to be an easy way to find and/or read library notes, but that this feature no longer works, presumably since lean4.

This PR aims to remedy the situation by introducing the `#check_note "some tag"` command, which displays all library notes marked with the tag "some tag" that are declared before the command, including in imports.